### PR TITLE
Update versions and exports styles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Changed node-version to workflows release.yml to 20.
 - The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
 - Updated import demo examples.
+- Updated documentation for usage in SSR and Nuxt applications.
 
 ### 📦 Dependencies
 - Updated Vite to `^7.0.0` to ensure compatibility with Node.js 20.19+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ---
 # Changelog
 
+## [1.0.1] - 2025-10-17
+### 🛠️ Changed
+- Changed node-version to workflows release.yml to 20.
+- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
+- Updated import demo examples.
+
+### 📦 Dependencies
+- Updated Vite to `^7.0.0` to ensure compatibility with Node.js 20.19+.
+- Updated @vitejs/plugin-vue to `^6.0.0`
+
 ## [1.0.0] - 2025-05-05
 ### ✨ Added
 - Initial release of `TvLabel` component.
@@ -18,4 +28,5 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Integrated styles for seamless appearance in any layout.
 - Ready-to-use demo and documentation site.
 
+[1.0.1]: https://github.com/TODOvue/todovue-label/pull/6/files
 [1.0.0]: https://github.com/TODOvue/todovue-label/pull/5/files

--- a/README.md
+++ b/README.md
@@ -1,89 +1,357 @@
 <p align="center"><img width="150" src="https://firebasestorage.googleapis.com/v0/b/todovue-blog.appspot.com/o/logo.png?alt=media&token=d8eb592f-e4a9-4b02-8aff-62d337745f41" alt="TODOvue logo">
 </p>
 
-# TODOvue Label
-###### TvLabel is a lightweight and customizable label (chip) component designed to highlight statuses, categories, or tags within your UI.
+# TODOvue Label (TvLabel)
+A lightweight and customizable label (chip) component for Vue 3 designed to highlight statuses,
+categories, or tags within your UI.
+Perfect for Single Page Apps or Server-Side Rendered (SSR) environments (e.g. Nuxt 3).
 
+[![npm](https://img.shields.io/npm/v/@todovue/tv-label.svg)](https://www.npmjs.com/package/@todovue/tv-label) 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/8c4f297a-52d3-46a9-993c-0d39ac25a643/deploy-status)](https://app.netlify.com/sites/tv-label/deploys) 
+[![npm downloads](https://img.shields.io/npm/dm/@todovue/tv-label.svg)](https://www.npmjs.com/package/@todovue/tv-label)
+[![npm total downloads](https://img.shields.io/npm/dt/@todovue/tv-label.svg)](https://www.npmjs.com/package/@todovue/tv-label) 
+![License](https://img.shields.io/github/license/TODOvue/tv-label) 
+![GitHub Release Date](https://img.shields.io/github/release-date/TODOvue/tv-label)
 
+> Demo: https://tv-label.netlify.app/
 
-[![npm](https://img.shields.io/npm/v/@todovue/tv-label.svg)](https://www.npmjs.com/package/@todovue/tv-label) [![Netlify Status](https://api.netlify.com/api/v1/badges/8c4f297a-52d3-46a9-993c-0d39ac25a643/deploy-status)](https://app.netlify.com/sites/tv-label/deploys) [![npm](https://img.shields.io/npm/dm/@todovue/tv-label.svg)](https://www.npmjs.com/package/@todovue/tv-label)
-[![npm](https://img.shields.io/npm/dt/@todovue/tv-label.svg)](https://www.npmjs.com/package/@todovue/tv-label) ![GitHub](https://img.shields.io/github/license/TODOvue/tv-label) ![GitHub Release Date](https://img.shields.io/github/release-date/TODOvue/tv-label)
+---
 
 ## Table of Contents
-- [Demo](https://tv-label.netlify.app/)
+- [Features](#features)
 - [Installation](#installation)
-- [Usage](#usage)
+- [Quick Start (SPA)](#quick-start-spa)
+- [Nuxt 3 / SSR Usage](#nuxt-3--ssr-usage)
+- [Component Registration Options](#component-registration-options)
 - [Props](#props)
 - [Events](#events)
+- [Slots](#slots)
+- [Customization (Styles / Theming)](#customization-styles--theming)
+- [Icon Usage](#icon-usage)
+- [Accessibility](#accessibility)
+- [SSR Notes](#ssr-notes)
 - [Development](#development)
-- [Changelog](https://github.com/TODOvue/tv-label/blob/main/CHANGELOG.md)
-- [Contributing](https://github.com/TODOvue/tv-label/blob/main/CONTRIBUTING.md)
-- [License](https://github.com/TODOvue/tv-label/blob/main/LICENSE)
+- [Changelog](#changelog)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Features
+- Customizable color schemes with automatic opacity handling
+- Optional edit and remove icons
+- Flexible icon positioning (left or right)
+- Custom text color support
+- Slot-based or prop-based content
+- Click event handling
+- SSR compatible (works in Nuxt 3)
+- Lightweight and performant
+- Tree-shake friendly (Vue marked external in library build)
+
+---
 
 ## Installation
-Install with npm or yarn
+Using npm:
 ```bash
 npm install @todovue/tv-label
 ```
+Using yarn:
 ```bash
 yarn add @todovue/tv-label
 ```
-Import
-```js
-import TvLabel from '@todovue/tv-label'
+Using pnpm:
+```bash
+pnpm add @todovue/tv-label
 ```
 
-You can also import it directly in the **main.js** file, so you don't have to import it in the pages
-```js
-import { createApp } from "vue";
-import App from "./App.vue";
-import TvLabel from "@todovue/tv-label";
+---
 
-const app = createApp(App);
-app.component("TvLabel", TvLabel);
-app.mount("#app");
+## Quick Start (SPA)
+Global registration (main.js / main.ts):
+```js
+import { createApp } from 'vue'
+import App from './App.vue'
+import { TvLabel } from '@todovue/tv-label'
+
+createApp(App)
+  .use(TvLabel) // enables <TvLabel /> globally
+  .mount('#app')
 ```
 
-## Usage
-```html
+Local import inside a component:
+```vue
+<script setup>
+import { TvLabel } from '@todovue/tv-label'
+
+const clickHandler = () => {
+  console.log('Label clicked')
+}
+</script>
+
 <template>
-  <tv-label @click-label="clickHandler" color="#4FC08D">
+  <TvLabel @click-label="clickHandler" color="#4FC08D">
     Vue
-  </tv-label>
+  </TvLabel>
+</template>
+```
+
+---
+
+## Nuxt 3 / SSR Usage
+Create a plugin file: `plugins/tv-label.client.ts` (client-only is fine, or without suffix for SSR as it is safe):
+```ts
+import { defineNuxtPlugin } from '#app'
+import TvLabel from '@todovue/tv-label'
+
+export default defineNuxtPlugin(nuxtApp => {
+  nuxtApp.vueApp.use(TvLabel)
+})
+```
+
+Use anywhere in your Nuxt app:
+```vue
+<template>
+  <TvLabel color="#42b883" :isEdit="true">
+    Editable Label
+  </TvLabel>
+</template>
+```
+
+Optional direct import (no plugin):
+```vue
+<script setup>
+import { TvLabel } from '@todovue/tv-label'
+</script>
+
+<template>
+  <TvLabel color="#ff6b6b" :isRemove="true">
+    Removable Tag
+  </TvLabel>
+</template>
+```
+
+---
+
+## Component Registration Options
+| Approach                                                        | When to use                                    |
+|-----------------------------------------------------------------|------------------------------------------------|
+| Global via `app.use(TvLabel)`                                   | Many usages across app / design system install |
+| Global via `app.use(TvLabelPlugin)`                             | Alternative plugin syntax                      |
+| Local named import `{ TvLabel }`                                | Isolated / code-split contexts                 |
+| Direct default import `import TvLabel from '@todovue/tv-label'` | Single usage or manual registration            |
+
+---
+
+## Props
+| Prop         | Type    | Default     | Description                                                                             |
+|--------------|---------|-------------|-----------------------------------------------------------------------------------------|
+| color        | String  | `''`        | Label background color in hexadecimal (e.g., `#4FC08D`). Automatically applies opacity. |
+| textLabel    | String  | `''`        | Text content for the label (alternative to using the default slot).                     |
+| textColor    | String  | `'inherit'` | Text color for the label content.                                                       |
+| isEdit       | Boolean | `false`     | Show edit icon inside the label.                                                        |
+| isRemove     | Boolean | `false`     | Show remove icon inside the label.                                                      |
+| iconPosition | String  | `'right'`   | Position of icons relative to text: `'left'` or `'right'`.                              |
+
+---
+
+## Events
+| Event name (kebab) | Emits (camel) | Description                                                |
+|--------------------|---------------|------------------------------------------------------------|
+| `click-label`      | `clickLabel`  | Custom semantic click event emitted when label is clicked. |
+| `click`            | `click`       | Native click event (also emitted).                         |
+
+Usage examples:
+```vue
+<template>
+  <!-- Using custom event -->
+  <TvLabel @click-label="handleLabelClick" color="#3498db">
+    Click me
+  </TvLabel>
+
+  <!-- Using native click event -->
+  <TvLabel @click="handleClick" color="#e74c3c">
+    Native click
+  </TvLabel>
+
+  <!-- Both events work simultaneously -->
+  <TvLabel 
+    @click-label="handleCustom" 
+    @click="handleNative" 
+    color="#9b59b6"
+  >
+    Dual events
+  </TvLabel>
 </template>
 
 <script setup>
-  import TvLabel from "@todovue/tv-label"; // Only if you have not imported it from main
-  
-   const clickHandler = () => {
-    console.log("clicked");
-  }
+const handleLabelClick = () => {
+  console.log('Custom click-label event')
+}
+
+const handleClick = () => {
+  console.log('Native click event')
+}
+
+const handleCustom = () => {
+  console.log('Custom handler')
+}
+
+const handleNative = () => {
+  console.log('Native handler')
+}
 </script>
 ```
 
-## Props
-| Name         | Type    | Default     | Description                                                              |
-|--------------|---------|-------------|--------------------------------------------------------------------------|
-| color        | String  | `''`        | label color in hexadecimal                                               |
-| textLabel    | String  | `''`        | If you don't want to send the name by slot you can send it by property   |
-| isEdit       | Boolean | `false`     | If you want to show the edit icon                                        |
-| isRemove     | Boolean | `false`     | If you want to show the remove icon                                      |
-| iconPosition | String  | `right`     | If you want to show the icons on the `left` or `right` side of the label |
-| textColor    | String  | `'inherit'` | Text color                                                               |
+---
 
-## Events
-| Name        | Description                                       |
-|-------------|---------------------------------------------------|
-| click-label | Event that is triggered when the label is clicked |
-| click       | Event that is triggered when the label is clicked |
+## Slots
+| Slot name | Description                                                                  |
+|-----------|------------------------------------------------------------------------------|
+| default   | Main content slot for label text. If not provided, `textLabel` prop is used. |
+
+Example:
+```vue
+<template>
+  <!-- Using slot -->
+  <TvLabel color="#4FC08D">
+    <strong>Vue 3</strong> Framework
+  </TvLabel>
+
+  <!-- Using textLabel prop -->
+  <TvLabel color="#4FC08D" textLabel="Vue 3 Framework" />
+</template>
+```
+
+---
+
+## Customization (Styles / Theming)
+The component automatically handles color opacity and border styling based on the `color` prop:
+
+```vue
+<template>
+  <!-- Green label -->
+  <TvLabel color="#4FC08D">Success</TvLabel>
+
+  <!-- Red label with custom text color -->
+  <TvLabel color="#f56565" textColor="#ffffff">Error</TvLabel>
+
+  <!-- Blue label with white text -->
+  <TvLabel color="#3182ce" textColor="#fff">Info</TvLabel>
+
+  <!-- Custom brand color -->
+  <TvLabel color="#6366f1" textColor="#e0e7ff">Brand</TvLabel>
+</template>
+```
+
+The component applies:
+- Background color with automatic opacity (lighter shade)
+- 2px solid border using the full color
+- Customizable text color via `textColor` prop
+
+---
+
+## Icon Usage
+Display edit or remove icons within your labels:
+
+```vue
+<template>
+  <!-- Edit icon on the right (default) -->
+  <TvLabel color="#4FC08D" :isEdit="true">
+    Editable
+  </TvLabel>
+
+  <!-- Remove icon on the right -->
+  <TvLabel color="#f56565" :isRemove="true">
+    Removable
+  </TvLabel>
+
+  <!-- Edit icon on the left -->
+  <TvLabel color="#3182ce" :isEdit="true" iconPosition="left">
+    Edit Left
+  </TvLabel>
+
+  <!-- Remove icon on the left -->
+  <TvLabel color="#9f7aea" :isRemove="true" iconPosition="left">
+    Remove Left
+  </TvLabel>
+
+  <!-- With click handler -->
+  <TvLabel 
+    color="#ed8936" 
+    :isEdit="true" 
+    @click-label="handleEdit"
+  >
+    Click to Edit
+  </TvLabel>
+</template>
+
+<script setup>
+const handleEdit = () => {
+  console.log('Edit action triggered')
+}
+</script>
+```
+
+---
+
+## Accessibility
+- **Semantic HTML**: The component uses a `<div>` with click handlers. For better accessibility, consider wrapping in a `<button>` if it represents an interactive action.
+- **Color contrast**: Ensure sufficient contrast between `color` and `textColor` for readability.
+- **Interactive labels**: When using `isEdit` or `isRemove`, consider adding ARIA attributes or wrapping in semantic elements.
+
+Best practices:
+```vue
+<template>
+  <!-- For non-interactive labels (display only) -->
+  <TvLabel color="#4FC08D">Status: Active</TvLabel>
+
+  <!-- For interactive labels, consider adding role or wrapping -->
+  <div role="button" tabindex="0" @keydown.enter="handleAction">
+    <TvLabel color="#3182ce" :isEdit="true" @click-label="handleAction">
+      Edit me
+    </TvLabel>
+  </div>
+</template>
+```
+
+---
+
+## SSR Notes
+- **SSR Compatible**: No direct DOM (`window` / `document`) access → safe for server-side rendering.
+- **Nuxt 3 Ready**: Works seamlessly in Nuxt 3 applications.
+- **Styles**: Component styles are scoped and work correctly in SSR environments.
+- **Icons**: SVG icons are embedded inline, ensuring they render correctly on the server.
+
+---
 
 ## Development
-Clone the repository and install the dependencies
+Clone the repository and install dependencies:
 ```bash
 git clone https://github.com/TODOvue/tv-label.git
 cd tv-label
 yarn install
+yarn dev     # run demo playground
+yarn build   # build library
 ```
+
+The demo is served from Vite using `index.html` and includes various usage examples.
+
 ---
+
+## Changelog
+See [CHANGELOG.md](https://github.com/TODOvue/tv-label/blob/main/CHANGELOG.md) for version history and updates.
+
+---
+
+## Contributing
+Contributions are welcome! Please read our [Contributing Guidelines](https://github.com/TODOvue/tv-label/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/TODOvue/tv-label/blob/main/CODE_OF_CONDUCT.md).
+
+---
+
 ## License
-[MIT](https://github.com/TODOvue/tv-label/blob/main/LICENSE)
+[MIT](https://github.com/TODOvue/tv-label/blob/main/LICENSE) © TODOvue
+
+---
+
+### Attributions
+Crafted for the TODOvue component ecosystem

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "dev": "vite",
@@ -52,9 +52,9 @@
   },
   "devDependencies": {
     "@todovue/tv-demo": "^1.0.0",
-    "@vitejs/plugin-vue": "^5.0.0",
+    "@vitejs/plugin-vue": "^6.0.0",
     "sass": "^1.0.0",
-    "vite": "^6.0.0",
+    "vite": "^7.0.0",
     "vite-plugin-css-injected-by-js": "^3.0.0",
     "vite-plugin-dts": "^4.0.0"
   }

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { defineAsyncComponent } from 'vue'
-import TvDemo from '@todovue/tv-demo'
+import { TvDemo } from '@todovue/tv-demo'
 import { demos } from '../utils/mocks.js'
 
 const TvLabel = defineAsyncComponent(() => import('../components/TvLabel.vue'))
@@ -14,6 +14,6 @@ const TvLabel = defineAsyncComponent(() => import('../components/TvLabel.vue'))
     npmInstall="@todovue/tv-label"
     sourceLink="https://github.com/TODOvue/tv-label"
     urlClone="https://github.com/TODOvue/tv-label.git"
-    version="1.0.0"
+    version="1.0.1"
   ></tv-demo>
 </template>

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,4 +1,14 @@
 import TvLabel from './components/TvLabel.vue'
 
+(TvLabel as any).install = (app: any) => {
+  app.component('TvLabel', TvLabel)
+};
+
+export const TvLabelPlugin = {
+  install(app: any) {
+    app.component('TvLabel', TvLabel)
+  }
+}
+
 export { TvLabel }
 export default TvLabel

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,4 @@
 import { createApp } from 'vue'
-import './style.css'
 import TvLabel from './demo/Demo.vue'
-import 'github-markdown-css';
-import '../src/assets/scss/_global.scss'
 
 createApp(TvLabel).mount('#tv-label')

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,0 @@
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}

--- a/src/utils/demos/color.vue
+++ b/src/utils/demos/color.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup>
-import TvLabel from '@todovue/tv-label';
+import { TvLabel } from '@todovue/tv-label';
 
 const clickHandler = () => {
   console.log("clicked");

--- a/src/utils/demos/color2.vue
+++ b/src/utils/demos/color2.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup>
-import TvLabel from '@todovue/tv-label';
+import { TvLabel } from '@todovue/tv-label';
 
 const clickHandler = () => {
   console.log("clicked");

--- a/src/utils/demos/color3.vue
+++ b/src/utils/demos/color3.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup>
-import TvLabel from '@todovue/tv-label';
+import { TvLabel } from '@todovue/tv-label';
 
 const clickHandler = () => {
   console.log("clicked");

--- a/src/utils/demos/default.vue
+++ b/src/utils/demos/default.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup>
-import TvLabel from '@todovue/tv-label';
+import { TvLabel } from '@todovue/tv-label';
 
 const clickHandler = () => {
   console.log("clicked");

--- a/src/utils/demos/defaultProps.vue
+++ b/src/utils/demos/defaultProps.vue
@@ -8,7 +8,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import TvLabel from '@todovue/tv-label';
+import { TvLabel } from '@todovue/tv-label';
 
 const properties = ref({
   name: "Default",

--- a/src/utils/demos/withIcon.vue
+++ b/src/utils/demos/withIcon.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup>
-import TvLabel from '@todovue/tv-label';
+import { TvLabel } from '@todovue/tv-label';
 
 const clickHandler = () => {
   console.log("clicked");

--- a/src/utils/demos/withIconLeft.vue
+++ b/src/utils/demos/withIconLeft.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup>
-import TvLabel from '@todovue/tv-label';
+import { TvLabel } from '@todovue/tv-label';
 
 const clickHandler = () => {
   console.log("clicked");

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,7 +31,8 @@ export default defineConfig({
         output: {
           globals: {
             vue: "Vue"
-          }
+          },
+          exports: 'named'
         }
       }
     },


### PR DESCRIPTION
## [1.0.1] - 2025-10-17
### 🛠️ Changed
- Changed node-version to workflows release.yml to 20.
- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
- Updated import demo examples.
- Updated documentation for usage in SSR and Nuxt applications.

### 📦 Dependencies
- Updated Vite to `^7.0.0` to ensure compatibility with Node.js 20.19+.
- Updated @vitejs/plugin-vue to `^6.0.0`