### PR TITLE
[1.2.3] - 2026-01-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@todovue/tv-label` will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.3] - 2026-01-27
+
+### Changed
+- Moved the `@todovue/tv-demo` component import from main.js to `Demo.vue` to localize its usage.
+
+### Removed
+- Eliminated the global import of the `@todovue/tv-demo` component from `main.js`.
+
 ## [1.2.2] - 2026-01-26
 
 ### Changed
@@ -110,6 +118,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Integrated styles for seamless appearance in any layout.
 - Ready-to-use demo and documentation site.
 
+[1.2.3]: https://github.com/TODOvue/todovue-label/pull/15/files
 [1.2.2]: https://github.com/TODOvue/todovue-label/pull/14/files
 [1.2.1]: https://github.com/TODOvue/todovue-label/pull/13/files
 [1.2.0]: https://github.com/TODOvue/todovue-label/pull/12/files

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { defineAsyncComponent } from 'vue'
+import { TvDemo } from '@todovue/tv-demo'
 import { demos } from './utils/mocks.js'
 
 const TvLabel = defineAsyncComponent(() => import('../components/TvLabel.vue'))
@@ -14,6 +15,6 @@ const TvLabel = defineAsyncComponent(() => import('../components/TvLabel.vue'))
     npm-install="@todovue/tv-label"
     source-link="https://github.com/TODOvue/tv-label"
     url-clone="https://github.com/TODOvue/tv-label.git"
-    version="1.2.2"
+    version="1.2.3"
   />
 </template>

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,7 @@
 import { createApp } from 'vue'
-import { TvDemo } from '@todovue/tv-demo'
 import TvLabel from './demo/Demo.vue'
 import '@todovue/tv-demo/style.css'
 import './style.scss'
 
 const app = createApp(TvLabel)
-app.component('TvDemo', TvDemo)
 app.mount('#tv-label')


### PR DESCRIPTION
### Changed
- Moved the `@todovue/tv-demo` component import from main.js to `Demo.vue` to localize its usage.

### Removed
- Eliminated the global import of the `@todovue/tv-demo` component from `main.js`.